### PR TITLE
Add RomanNumeralExtensions tests

### DIFF
--- a/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/IsValidRomanNumeralTests.cs
+++ b/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/IsValidRomanNumeralTests.cs
@@ -1,0 +1,8 @@
+﻿namespace MoreDotNet.Tests.Extensions.Numeric.RomanNumeralExtensions
+{
+    using Xunit;
+
+    public class IsValidRomanNumeralTests
+    {
+    }
+}

--- a/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/IsValidRomanNumeralTests.cs
+++ b/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/IsValidRomanNumeralTests.cs
@@ -1,8 +1,212 @@
 ﻿namespace MoreDotNet.Tests.Extensions.Numeric.RomanNumeralExtensions
 {
+    using MoreDotNet.Extensions.Numeric;
     using Xunit;
 
     public class IsValidRomanNumeralTests
     {
+        [Fact]
+        public void IsValidRomanNumeral_GivenI_ShouldReturnTrue()
+        {
+            Assert.True("I".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenII_ShouldReturnTrue()
+        {
+            Assert.True("II".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenIII_ShouldReturnTrue()
+        {
+            Assert.True("III".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenIV_ShouldReturnTrue()
+        {
+            Assert.True("IV".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenV_ShouldReturnTrue()
+        {
+            Assert.True("V".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenVI_ShouldReturnTrue()
+        {
+            Assert.True("VI".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenVII_ShouldReturnTrue()
+        {
+            Assert.True("VII".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenVIII_ShouldReturnTrue()
+        {
+            Assert.True("VIII".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenIX_ShouldReturnTrue()
+        {
+            Assert.True("IX".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenX_ShouldReturnTrue()
+        {
+            Assert.True("X".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenXII_ShouldReturnTrue()
+        {
+            Assert.True("XII".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenXVI_ShouldReturnTrue()
+        {
+            Assert.True("XVI".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenXXIX_ShouldReturnTrue()
+        {
+            Assert.True("XXIX".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenXLIV_ShouldReturnTrue()
+        {
+            Assert.True("XLIV".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenXLV_ShouldReturnTrue()
+        {
+            Assert.True("XLV".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenL_ShouldReturnTrue()
+        {
+            Assert.True("L".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenLXVIII_ShouldReturnTrue()
+        {
+            Assert.True("LXVIII".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenLXXXIII_ShouldReturnTrue()
+        {
+            Assert.True("LXXXIII".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenXCVII_ShouldReturnTrue()
+        {
+            Assert.True("XCVII".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenXCIX_ShouldReturnTrue()
+        {
+            Assert.True("XCIX".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenC_ShouldReturnTrue()
+        {
+            Assert.True("C".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenD_ShouldReturnTrue()
+        {
+            Assert.True("D".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenDI_ShouldReturnTrue()
+        {
+            Assert.True("DI".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenDCXLIX_ShouldReturnTrue()
+        {
+            Assert.True("DCXLIX".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenDCCXCVIII_ShouldReturnTrue()
+        {
+            Assert.True("DCCXCVIII".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenDCCCXCI_ShouldReturnTrue()
+        {
+            Assert.True("DCCCXCI".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenM_ShouldReturnTrue()
+        {
+            Assert.True("M".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenMIV_ShouldReturnTrue()
+        {
+            Assert.True("MIV".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenMVI_ShouldReturnTrue()
+        {
+            Assert.True("MVI".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenMXXIII_ShouldReturnTrue()
+        {
+            Assert.True("MXXIII".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenMMXIV_ShouldReturnTrue()
+        {
+            Assert.True("MMXIV".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenMMMCMXCIX_ShouldReturnTrue()
+        {
+            Assert.True("MMMCMXCIX".IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenEmptyString_ShouldReturnFalse()
+        {
+            Assert.False(string.Empty.IsValidRomanNumeral());
+        }
+
+        [Fact]
+        public void IsValidRomanNumeral_GivenIIII_ShouldReturnFalse()
+        {
+            Assert.False("IIII".IsValidRomanNumeral());
+        }
     }
 }

--- a/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ParseRomanNumeralTests.cs
+++ b/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ParseRomanNumeralTests.cs
@@ -297,7 +297,7 @@
         [Fact]
         public void ParseRomanNumeral_GivenEmptyString_ShouldThrowArgumentException()
         {
-            var input = String.Empty;
+            var input = string.Empty;
             var exception = Assert.Throws<ArgumentException>(() => input.ParseRomanNumeral());
             Assert.Equal("Empty or invalid Roman numeral string.\r\nParameter name: input", exception.Message);
         }
@@ -306,6 +306,14 @@
         public void ParseRomanNumeral_GivenIIII_ShouldThrowArgumentException()
         {
             var input = "IIII";
+            var exception = Assert.Throws<ArgumentException>(() => input.ParseRomanNumeral());
+            Assert.Equal("Empty or invalid Roman numeral string.\r\nParameter name: input", exception.Message);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenMMMM_ShouldThrowArgumentException()
+        {
+            var input = "MMMM";
             var exception = Assert.Throws<ArgumentException>(() => input.ParseRomanNumeral());
             Assert.Equal("Empty or invalid Roman numeral string.\r\nParameter name: input", exception.Message);
         }

--- a/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ParseRomanNumeralTests.cs
+++ b/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ParseRomanNumeralTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace MoreDotNet.Tests.Extensions.Numeric.RomanNumeralExtensions
 {
     using MoreDotNet.Extensions.Numeric;
+    using System;
     using Xunit;
 
     public class ParseRomanNumeralTests
@@ -291,6 +292,22 @@
             var input = "MMMCMXCIX";
             var actual = input.ParseRomanNumeral();
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenEmptyString_ShouldThrowArgumentException()
+        {
+            var input = String.Empty;
+            var exception = Assert.Throws<ArgumentException>(() => input.ParseRomanNumeral());
+            Assert.Equal("Empty or invalid Roman numeral string.\r\nParameter name: input", exception.Message);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenIIII_ShouldThrowArgumentException()
+        {
+            var input = "IIII";
+            var exception = Assert.Throws<ArgumentException>(() => input.ParseRomanNumeral());
+            Assert.Equal("Empty or invalid Roman numeral string.\r\nParameter name: input", exception.Message);
         }
     }
 }

--- a/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ParseRomanNumeralTests.cs
+++ b/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ParseRomanNumeralTests.cs
@@ -1,0 +1,296 @@
+﻿namespace MoreDotNet.Tests.Extensions.Numeric.RomanNumeralExtensions
+{
+    using MoreDotNet.Extensions.Numeric;
+    using Xunit;
+
+    public class ParseRomanNumeralTests
+    {
+        [Fact]
+        public void ParseRomanNumeral_GivenI_ShouldReturn1()
+        {
+            var expected = 1;
+            var input = "I";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenII_ShouldReturn2()
+        {
+            var expected = 2;
+            var input = "II";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenIII_ShouldReturn3()
+        {
+            var expected = 3;
+            var input = "III";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenIV_ShouldReturn4()
+        {
+            var expected = 4;
+            var input = "IV";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenV_ShouldReturn5()
+        {
+            var expected = 5;
+            var input = "V";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenVI_ShouldReturn6()
+        {
+            var expected = 6;
+            var input = "VI";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenVII_ShouldReturn7()
+        {
+            var expected = 7;
+            var input = "VII";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenVIII_ShouldReturn8()
+        {
+            var expected = 8;
+            var input = "VIII";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenIX_ShouldReturn9()
+        {
+            var expected = 9;
+            var input = "IX";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenX_ShouldReturn10()
+        {
+            var expected = 10;
+            var input = "X";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenXII_ShouldReturn12()
+        {
+            var expected = 12;
+            var input = "XII";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenXVI_ShouldReturn16()
+        {
+            var expected = 16;
+            var input = "XVI";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenXXIX_ShouldReturn29()
+        {
+            var expected = 29;
+            var input = "XXIX";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenXLIV_ShouldReturn44()
+        {
+            var expected = 44;
+            var input = "XLIV";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenXLV_ShouldReturn45()
+        {
+            var expected = 45;
+            var input = "XLV";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenL_ShouldReturn50()
+        {
+            var expected = 50;
+            var input = "L";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenLXVIII_ShouldReturn68()
+        {
+            var expected = 68;
+            var input = "LXVIII";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenLXXXIII_ShouldReturn83()
+        {
+            var expected = 83;
+            var input = "LXXXIII";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenXCVII_ShouldReturn97()
+        {
+            var expected = 97;
+            var input = "XCVII";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenXCIX_ShouldReturn99()
+        {
+            var expected = 99;
+            var input = "XCIX";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenC_ShouldReturn100()
+        {
+            var expected = 100;
+            var input = "C";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenD_ShouldReturn500()
+        {
+            var expected = 500;
+            var input = "D";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenDI_ShouldReturn501()
+        {
+            var expected = 501;
+            var input = "DI";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenDCXLIX_ShouldReturn649()
+        {
+            var expected = 649;
+            var input = "DCXLIX";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenDCCXCVIII_ShouldReturn798()
+        {
+            var expected = 798;
+            var input = "DCCXCVIII";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenDCCCXCI_ShouldReturn891()
+        {
+            var expected = 891;
+            var input = "DCCCXCI";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenM_ShouldReturn1000()
+        {
+            var expected = 1000;
+            var input = "M";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenMIV_ShouldReturn1004()
+        {
+            var expected = 1004;
+            var input = "MIV";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenMVI_ShouldReturn1006()
+        {
+            var expected = 1006;
+            var input = "MVI";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenMXXIII_ShouldReturn1023()
+        {
+            var expected = 1023;
+            var input = "MXXIII";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenMMXIV_ShouldReturn2014()
+        {
+            var expected = 2014;
+            var input = "MMXIV";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseRomanNumeral_GivenMMMCMXCIX_ShouldReturn3999()
+        {
+            var expected = 3999;
+            var input = "MMMCMXCIX";
+            var actual = input.ParseRomanNumeral();
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ToRomanNumeralStringTests.cs
+++ b/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ToRomanNumeralStringTests.cs
@@ -1,0 +1,18 @@
+﻿namespace MoreDotNet.Tests.Extensions.Numeric.RomanNumeralExtensions
+{
+    using MoreDotNet.Extensions.Numeric;
+    using Xunit;
+
+    public class ToRomanNumeralStringTests
+    {
+        [Fact]
+        public void ToRomanNumeralString_Given1_ShouldReturnI()
+        {
+            var expected = "I";
+            var input = 1;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+    }
+}

--- a/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ToRomanNumeralStringTests.cs
+++ b/Source/MoreDotNet.Test/Extensions/Numeric/RomanNumeralExtensions/ToRomanNumeralStringTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MoreDotNet.Tests.Extensions.Numeric.RomanNumeralExtensions
 {
+    using System;
     using MoreDotNet.Extensions.Numeric;
     using Xunit;
 
@@ -14,5 +15,297 @@
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void ToRomanNumeralString_Given2_ShouldReturnII()
+        {
+            var expected = "II";
+            var input = 2;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given3_ShouldReturnIII()
+        {
+            var expected = "III";
+            var input = 3;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given4_ShouldReturnIV()
+        {
+            var expected = "IV";
+            var input = 4;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given5_ShouldReturnV()
+        {
+            var expected = "V";
+            var input = 5;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given6_ShouldReturnVI()
+        {
+            var expected = "VI";
+            var input = 6;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given7_ShouldReturnVII()
+        {
+            var expected = "VII";
+            var input = 7;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given8_ShouldReturnVIII()
+        {
+            var expected = "VIII";
+            var input = 8;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given9_ShouldReturnIX()
+        {
+            var expected = "IX";
+            var input = 9;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given10_ShouldReturnX()
+        {
+            var expected = "X";
+            var input = 10;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given12_ShouldReturnXII()
+        {
+            var expected = "XII";
+            var input = 12;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given16_ShouldReturnXVI()
+        {
+            var expected = "XVI";
+            var input = 16;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Give29_ShouldReturnXXIX()
+        {
+            var expected = "XXIX";
+            var input = 29;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Give44_ShouldReturnXLIV()
+        {
+            var expected = "XLIV";
+            var input = 44;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given45_ShouldReturnXLV()
+        {
+            var expected = "XLV";
+            var input = 45;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given50_ShouldReturnL()
+        {
+            var expected = "L";
+            var input = 50;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given68_ShouldReturnLXVIII()
+        {
+            var expected = "LXVIII";
+            var input = 68;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given83_ShouldReturnLXXXIII()
+        {
+            var expected = "LXXXIII";
+            var input = 83;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given97_ShouldReturnXCVII()
+        {
+            var expected = "XCVII";
+            var input = 97;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given99_ShouldReturnXCIX()
+        {
+            var expected = "XCIX";
+            var input = 99;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given100_ShouldReturnC()
+        {
+            var expected = "C";
+            var input = 100;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given500_ShouldReturnD()
+        {
+            var expected = "D";
+            var input = 500;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given501_ShouldReturnDI()
+        {
+            var expected = "DI";
+            var input = 501;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given649_ShouldReturnDCXLIX()
+        {
+            var expected = "DCXLIX";
+            var input = 649;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given798_ShouldReturnDCCXCVIII()
+        {
+            var expected = "DCCXCVIII";
+            var input = 798;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given891_ShouldReturnDCCCXCI()
+        {
+            var expected = "DCCCXCI";
+            var input = 891;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given1000_ShouldReturnM()
+        {
+            var expected = "M";
+            var input = 1000;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given1004_ShouldReturnMIV()
+        {
+            var expected = "MIV";
+            var input = 1004;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given1006_ShouldReturnMVI()
+        {
+            var expected = "MVI";
+            var input = 1006;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given1023_ShouldReturnMXXIII()
+        {
+            var expected = "MXXIII";
+            var input = 1023;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given2014_ShouldReturnMMXIV()
+        {
+            var expected = "MMXIV";
+            var input = 2014;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given3999_ShouldReturnMMMCMXCIX()
+        {
+            var expected = "MMMCMXCIX";
+            var input = 3999;
+            var actual = input.ToRomanNumeralString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given0_ShouldThrowArgumentOutOfRangeException()
+        {
+            var input = 0;
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => input.ToRomanNumeralString());
+        }
+
+        [Fact]
+        public void ToRomanNumeralString_Given4000_ShouldThrowArgumentOutOfRangeException()
+        {
+            var input = 4000;
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => input.ToRomanNumeralString());
+        }
     }
 }

--- a/Source/MoreDotNet.Test/MoreDotNet.Tests.csproj
+++ b/Source/MoreDotNet.Test/MoreDotNet.Tests.csproj
@@ -136,6 +136,9 @@
     <Compile Include="Extensions\Common\StringExtensions\ToTitleCaseTests.cs" />
     <Compile Include="Extensions\Common\StringExtensions\CaseToWordsTests.cs" />
     <Compile Include="Extensions\Common\TypeExtensions\TypeExtensionsTests.cs" />
+    <Compile Include="Extensions\Numeric\RomanNumeralExtensions\IsValidRomanNumeralTests.cs" />
+    <Compile Include="Extensions\Numeric\RomanNumeralExtensions\ParseRomanNumeralTests.cs" />
+    <Compile Include="Extensions\Numeric\RomanNumeralExtensions\ToRomanNumeralStringTests.cs" />
     <Compile Include="Helpers\FileHelpers\SaveByteArrayToTempFileTests.cs" />
     <Compile Include="Helpers\FileHelpers\SaveStringToTempFileTests.cs" />
     <Compile Include="Models\FakeSerializationClass.cs" />
@@ -166,6 +169,7 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>


### PR DESCRIPTION
Add tests for the 3 methods in RomanNumeralExtensions.
- [x]  Add ParseRomanNumeral tests  
- [x]  Add IsValidRomanNumeral tests  
- [x] Add ToRomanNumeralString tests 
